### PR TITLE
feat: improve chat typing feedback and input growth

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -82,11 +82,13 @@ pre {
   transition: opacity 400ms ease-in 200ms;
 }
 
-.typing-dot {
-  background-color: var(--chatbot-host-bubble-color);
-  opacity: 0.2;
-  animation: typingBlink 1.2s infinite ease-in-out;
-}
+  .typing-dot {
+    background-color: var(--chatbot-host-bubble-color);
+    opacity: 0.2;
+    animation: typingBlink 1.2s infinite ease-in-out;
+    animation-fill-mode: both;
+    will-change: opacity;
+  }
 
 @keyframes typingBlink {
   0% {

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -82,42 +82,21 @@ pre {
   transition: opacity 400ms ease-in 200ms;
 }
 
-.bubble-typing {
-  transition:
-    width 400ms ease-out,
-    height 400ms ease-out;
-}
-
-.bubble1,
-.bubble2,
-.bubble3 {
+.typing-dot {
   background-color: var(--chatbot-host-bubble-color);
-  opacity: 0.5;
+  opacity: 0.2;
+  animation: typingBlink 1.2s infinite ease-in-out;
 }
 
-.bubble1 {
-  animation: chatBubbles 1s ease-in-out infinite;
-}
-
-.bubble2 {
-  animation: chatBubbles 1s ease-in-out infinite;
-  animation-delay: 0.3s;
-}
-
-.bubble3 {
-  animation: chatBubbles 1s ease-in-out infinite;
-  animation-delay: 0.5s;
-}
-
-@keyframes chatBubbles {
+@keyframes typingBlink {
   0% {
-    transform: translateY(0);
+    opacity: 0.2;
   }
   50% {
-    transform: translateY(-5px);
+    opacity: 1;
   }
   100% {
-    transform: translateY(0);
+    opacity: 0.2;
   }
 }
 
@@ -206,12 +185,6 @@ textarea {
   word-break: break-word;
   /* ensure it actually wraps instead of running off the screen */
   white-space: normal;
-}
-
-.chatbot-host-bubble > .bubble-typing {
-  background-color: #f7f8ff;
-  border: var(--chatbot-host-bubble-border);
-  border-radius: 6px;
 }
 
 .chatbot-host-bubble img,

--- a/src/components/Bot.tsx
+++ b/src/components/Bot.tsx
@@ -478,6 +478,13 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
   const [isMessageStopping, setIsMessageStopping] = createSignal(false);
   const [starterPrompts, setStarterPrompts] = createSignal<string[]>([], { equals: false });
   const [chatFeedbackStatus, setChatFeedbackStatus] = createSignal<boolean>(false);
+  const showTypingBubble = createMemo(() => {
+    if (!loading()) return false;
+    const msgs = messages();
+    const last = msgs[msgs.length - 1];
+    if (!last) return false;
+    return last.type === 'userMessage' || (last.type === 'apiMessage' && last.message === '');
+  });
   const [fullFileUpload, setFullFileUpload] = createSignal<boolean>(false);
   const [uploadsConfig, setUploadsConfig] = createSignal<UploadsConfig>();
   const [leadsConfig, setLeadsConfig] = createSignal<LeadsConfig>();
@@ -1876,12 +1883,13 @@ export const Bot = (botProps: BotProps & { class?: string }) => {
                           setLeadEmail={setLeadEmail}
                         />
                       )}
-                      {message.type === 'userMessage' && loading() && index() === messages().length - 1 && <LoadingBubble />}
-                      {message.type === 'apiMessage' && message.message === '' && loading() && index() === messages().length - 1 && <LoadingBubble />}
                     </>
                   );
                 }}
               </For>
+              <div classList={{ hidden: !showTypingBubble() }}>
+                <LoadingBubble />
+              </div>
             </div>
             <Show when={messages().length === 1}>
               <Show when={starterPrompts().length > 0}>

--- a/src/components/TypingBubble.tsx
+++ b/src/components/TypingBubble.tsx
@@ -1,7 +1,7 @@
 export const TypingBubble = () => (
   <div class="flex items-center">
-    <div class="w-2 h-2 mr-1 rounded-full bubble1" />
-    <div class="w-2 h-2 mr-1 rounded-full bubble2" />
-    <div class="w-2 h-2 rounded-full bubble3" />
+    <div class="w-2 h-2 mr-1 rounded-full typing-dot" style={{ 'animation-delay': '0s' }} />
+    <div class="w-2 h-2 mr-1 rounded-full typing-dot" style={{ 'animation-delay': '0.2s' }} />
+    <div class="w-2 h-2 rounded-full typing-dot" style={{ 'animation-delay': '0.4s' }} />
   </div>
 );

--- a/src/components/inputs/textInput/components/ShortTextInput.tsx
+++ b/src/components/inputs/textInput/components/ShortTextInput.tsx
@@ -21,7 +21,7 @@ export const ShortTextInput = (props: ShortTextInputProps) => {
         // reset height when value is empty
         setHeight(DEFAULT_HEIGHT);
       } else {
-        setHeight(e.currentTarget.scrollHeight - 24);
+        setHeight(Math.min(Math.max(e.currentTarget.scrollHeight, DEFAULT_HEIGHT), 128));
       }
       e.currentTarget.scrollTo(0, e.currentTarget.scrollHeight);
       local.onInput(e.currentTarget.value);


### PR DESCRIPTION
## Summary
- replace flickering typing bubbles with smooth fading dots
- expand text input based on content to avoid clipped second line

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test` (fails: Couldn't find a script named "test")

------
https://chatgpt.com/codex/tasks/task_e_68934c0ca23483319fa4cfa9b316aa97